### PR TITLE
added githook script to remove public/json and run build, test

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:server": "NODE_ENV=test mocha --compilers js:babel-core/register --recursive test/server",
     "watch": "NODE_ENV=production gulp watch",
     "watch-dev": "NODE_ENV=development gulp watch-dev",
-    "watch-sync": "NODE_ENV=development gulp browser-sync"
+    "watch-sync": "NODE_ENV=development gulp browser-sync",
+    "cp-githook": "echo \"Adding git-hook\" && cp ./bin/pre-push .git/hooks/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I think git-hook pre-push is needed, so campers won't push any broken code or untested code