### PR TITLE
Fixing Browser Sync Init Order

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -385,17 +385,18 @@ gulp.task('watch-dev', gulp.series('build-dev', done => {
 
 // Hot-reloading
 // -------------
-gulp.task('browser-sync', gulp.series('watch-dev', done => {
+gulp.task('browser-sync', gulp.series(done => {
   browserSync.init({
     proxy: {
       target: 'localhost:8080',
       ws: true // websockets
     },
     ghostMode: true, // sync across all browsers
-    reloadDelay: 2000, // give gulp tasks time to reprocess files
+    reloadDelay: 1000, // give gulp tasks time to reprocess files
+    reloadDebounce: 4000,
     port: 3000 // browserSync port
-  }, done);
-}));
+  }, done)
+}, 'watch-dev'));
 
 // GitHub pages deploy
 // -------------------


### PR DESCRIPTION
This fixes two bugs related to development locally:

1) There was an issue in the gulp setup where the files would start to be watched before calling browserSync.init which would cause a page to be loaded and not be refreshed.  This PR changes the order so that browserSync is invoked first, followed by watch-dev.

2) When watch-dev fires, browserSync.reload() is invoked multiple times; thus, the web page will try to reload that many times.  This is fixed by adding a debounce option to browserSync to only refresh the page once after all the reload calls are done being called.